### PR TITLE
pandoc reader for all markdown extensions

### DIFF
--- a/pandoc_reader.py
+++ b/pandoc_reader.py
@@ -36,8 +36,8 @@ class PandocReader(BaseReader):
 
 
 def add_reader(readers):
-    readers.reader_classes['md'] = PandocReader
-
+    for ext in PandocReader.file_extensions:
+        readers.reader_classes[ext] = PandocReader
 
 def register():
     signals.readers_init.connect(add_reader)


### PR DESCRIPTION
This makes the PandocReader the default markdown reader for all markdown extensions not just "md"
