### PR TITLE
Add optional parameter PANDOC_EXEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A pandoc [markdown] reader plugin for [pelican]
 Requirements
 ------------
 
-  - [pandoc] in $PATH
+  - [pandoc], ideally in $PATH but this is not mandatory.
 
 
 Installation
@@ -37,6 +37,15 @@ PANDOC_EXTENSIONS parameter.
       '-citations'
     ]
 
+In case [pandoc] is not in $PATH it is possible to provide the full path:
+
+    PANDOC_EXEC = '/usr/local/bin/pandoc'
+
+This parameter can also be used to call a variant of [pandoc] such as [scholdoc]:
+
+    PANDOC_EXEC = 'scholdoc'
+
+
 Contributing
 ------------
 
@@ -50,3 +59,4 @@ Contributing
 [markdown]: http://daringfireball.net/projects/markdown/
 [pandoc]: http://johnmacfarlane.net/pandoc/
 [pelican]: http://getpelican.com
+[scholdoc]: http://scholdoc.scholarlymarkdown.com/

--- a/pandoc_reader.py
+++ b/pandoc_reader.py
@@ -3,6 +3,7 @@ from pelican import signals
 from pelican.readers import BaseReader
 from pelican.utils import pelican_open
 
+
 class PandocReader(BaseReader):
     enabled = True
     file_extensions = ['md', 'markdown', 'mkd', 'mdown']
@@ -22,16 +23,17 @@ class PandocReader(BaseReader):
                 break
 
         extra_args = self.settings.get('PANDOC_ARGS', [])
+        executable = self.settings.get('PANDOC_EXEC', 'pandoc')
         extensions = self.settings.get('PANDOC_EXTENSIONS', '')
         if isinstance(extensions, list):
             extensions = ''.join(extensions)
 
-        pandoc_cmd = ["pandoc", "--from=markdown" + extensions, "--to=html5"]
+        pandoc_cmd = [executable, "--from=markdown" + extensions, "--to=html5"]
         pandoc_cmd.extend(extra_args)
 
         proc = subprocess.Popen(pandoc_cmd,
-                                stdin = subprocess.PIPE,
-                                stdout = subprocess.PIPE)
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE)
 
         output = proc.communicate(content.encode('utf-8'))[0].decode('utf-8')
         status = proc.wait()
@@ -40,9 +42,11 @@ class PandocReader(BaseReader):
 
         return output, metadata
 
+
 def add_reader(readers):
     for ext in PandocReader.file_extensions:
         readers.reader_classes[ext] = PandocReader
+
 
 def register():
     signals.readers_init.connect(add_reader)


### PR DESCRIPTION
This introduces an optional parameter to select the executable used for Pandoc. My main reason is that I'd like to use Scholdoc instead of Pandoc. This parameter can be used to provide the full path to the executable in case it's not in $PATH.

In the process I just fixed a few details for PEP8 conformity.
