### PR TITLE
[Dirty hack] to parse pandoc-style metadata correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements
 ------------
 
   - [pandoc] in $PATH
-
+  - PyYaml for metadata loading
 
 Installation
 ------------

--- a/pandoc_reader.py
+++ b/pandoc_reader.py
@@ -52,6 +52,10 @@ class PandocReader(BaseReader):
         if status:
             raise subprocess.CalledProcessError(status, pandoc_cmd)
 
+        # Need that to make {static} -like tags be available
+        output = output.replace("%7B", "{")
+        output = output.replace("%7D", "}")
+
         return output, finalmeta
 
 def add_reader(readers):


### PR DESCRIPTION
I realized the project is not able to process multiline metadata correctly. I added PyYaml to be able to solve that.
It's probably easier to solve without pyyaml and making use of pandoc itself but this PR's intention is to share that the multiline metadata is broken and this is why.

Thanks!